### PR TITLE
Fix for Loading widget image sequence not working while loading maps.

### DIFF
--- a/Source/AsyncLoadingScreen/Private/SLoadingWidget.cpp
+++ b/Source/AsyncLoadingScreen/Private/SLoadingWidget.cpp
@@ -83,7 +83,7 @@ void SLoadingWidget::ConstructLoadingIcon(const FLoadingWidgetSettings& Settings
 			if (!bIsActiveTimerRegistered)
 			{
 				bIsActiveTimerRegistered = true;
-				RegisterActiveTimer(Settings.ImageSequenceSettings.Interval, FWidgetActiveTimerDelegate::CreateSP(this, &SLoadingWidget::AnimatingImageSequence));
+				ImagePlayInterval = Settings.ImageSequenceSettings.Interval;
 			}
 		}
 		else
@@ -114,5 +114,21 @@ void SLoadingWidget::ConstructLoadingIcon(const FLoadingWidgetSettings& Settings
 	// Set Loading Icon render transform
 	LoadingIcon.Get().SetRenderTransform(FSlateRenderTransform(FScale2D(Settings.TransformScale), Settings.TransformTranslation));
 	LoadingIcon.Get().SetRenderTransformPivot(Settings.TransformPivot);
+}
+
+int32 SLoadingWidget::OnPaint(const FPaintArgs& Args, const FGeometry& AllottedGeometry, const FSlateRect& MyCullingRect, FSlateWindowElementList& OutDrawElements, int32 LayerId, const FWidgetStyle& InWidgetStyle, bool bParentEnabled) const
+{
+	static float TimeElapsed = 0.0f;
+	TimeElapsed += Args.GetDeltaTime();
+	if (bIsActiveTimerRegistered && TimeElapsed >= ImagePlayInterval)
+	{
+		// Definitely not clean code but engine does something similar in Widget::Paint function for SThrobber image animation during load.
+		TSharedRef<SWidget> MutableThis = ConstCastSharedRef<SWidget>(this->AsShared());
+		StaticCastSharedRef<SLoadingWidget>(MutableThis)->AnimatingImageSequence(Args.GetCurrentTime(), Args.GetDeltaTime());
+		TimeElapsed = 0.0f;
+	}
+
+	SCompoundWidget::OnPaint(Args, AllottedGeometry, MyCullingRect, OutDrawElements, LayerId, InWidgetStyle, bParentEnabled);
+	return LayerId;
 }
 	

--- a/Source/AsyncLoadingScreen/Public/SLoadingWidget.h
+++ b/Source/AsyncLoadingScreen/Public/SLoadingWidget.h
@@ -13,6 +13,7 @@
 
 class FDeferredCleanupSlateBrush;
 struct FLoadingWidgetSettings;
+struct FThrobberSettings;
 
 /**
  * Loading Widget base class
@@ -29,6 +30,8 @@ public:
 	/** Construct loading icon*/
 	void ConstructLoadingIcon(const FLoadingWidgetSettings& Settings);
 
+	virtual int32 OnPaint(const FPaintArgs& Args, const FGeometry& AllottedGeometry, const FSlateRect& MyCullingRect, FSlateWindowElementList& OutDrawElements, int32 LayerId, const FWidgetStyle& InWidgetStyle, bool bParentEnabled) const override;
+
 protected:
 	// Placeholder widgets
 	TSharedRef<SWidget> LoadingIcon = SNullWidget::NullWidget;
@@ -40,5 +43,6 @@ protected:
 	bool bPlayReverse = false;
 
 	bool bIsActiveTimerRegistered = false;
+	float ImagePlayInterval = 0.0f;
 	
 };


### PR DESCRIPTION
Hey Truong-Bui,
Thank you for the plugin. It is very useful and thought of sharing the fix for Image sequence not working while loading the map. The issue was that the ActiveTimers don't run during map load time. How Epic make the SThrobber run during map load is by using the SWidget::Paint function. Since that is a private function and the next best function was the SWidget::OnPaint function. I use that to tick call the SLoadingWidget::AnimatingImageSequence function. I do some nasty const to non-const **Don't Do** conversions but that is how Epic does it in SThrobber. So should be ok.

Also, I have only tried it for 4.25 hence contributing for that version. I think it should be good for other versions as well but didn't try it.

Hope this helps. Again thank you for such an amazing plugin. Please feel to reach out to me using the email mentioned below for any clarification for the same.

Regards
Nav
Email: navaneeth_3@hotmail.com