### PR TITLE
Fix stack-use-after-scope in SLoadingScreenLayout::GetDPIScale

### DIFF
--- a/Source/AsyncLoadingScreen/Private/SLoadingScreenLayout.cpp
+++ b/Source/AsyncLoadingScreen/Private/SLoadingScreenLayout.cpp
@@ -19,7 +19,7 @@ float SLoadingScreenLayout::PointSizeToSlateUnits(float PointSize)
 
 float SLoadingScreenLayout::GetDPIScale() const
 {
-	const FVector2D& DrawSize = GetTickSpaceGeometry().ToPaintGeometry().GetLocalSize();
+	const FVector2D DrawSize = GetTickSpaceGeometry().ToPaintGeometry().GetLocalSize();
 	const FIntPoint Size((int32)DrawSize.X, (int32)DrawSize.Y);
 	
 	return GetDefault<UUserInterfaceSettings>()->GetDPIScaleBasedOnSize(Size);


### PR DESCRIPTION
const ref to part of the struct cannot prolongate whole struct