### PR TITLE
Dev/fix zenloader crashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 </p>
 
 # Contents
+- [IMPORTANT NOTE](#IMPORTANT-NOTE)
 - [Trailer](#trailer)
 - [About](#about)
 - [How it works](#how-it-works)
 - [Features](#features)
-- [IMPORTANT NOTE](#IMPORTANT-NOTE)
 - [Changelog](#changelog)
 - [Requirements](#requirements)
 - [Installation](#installation)
@@ -33,6 +33,12 @@
 - [License](#license)
 - [Acknowledgment](#acknowledgment)
 
+# IMPORTANT NOTE
+- Texture Group should be set to UI and Compression Settings to UserInterface2D
+  <img width="616" height="377" alt="image" src="https://github.com/user-attachments/assets/3f3e90e5-6f35-4390-99b2-685446d9545c" />
+- Don't package the Movies folder into the .Pak file because MoviePlayer needs to look for the startup movies folder at "Contents/Movies" path
+- Make sure you don’t have any plugins enabled that conflict with ASL. For example, **Pre-Load Screen Movie Player**
+- **Background images will not appear in packaged games or Quick Launch** unless their asset folder is added to `AdditionalAssetDirectoriesToCook`. This is because the plugin loads at the `PreLoadingScreen` phase — before the asset streaming system is ready — so textures must be explicitly cooked. In `Project Settings → Packaging → Additional Asset Directories to Cook`, add the folder(s) containing your loading screen background images (e.g., `/Game/LoadingScreen/Backgrounds`). This applies to Image Sequence images as well.
 
 # Trailer
 
@@ -65,12 +71,6 @@ MoviePlayer is registered to PreLoadMap and PostLoadMapWithWorld delegates so it
 - No temporary maps, no level streaming.
 - Automatically handles all level transitions.
 - Integrates seamlessly with an existing project.
-
-# IMPORTANT NOTE
-- Texture Group should be set to UI and Compression Settings to UserInterface2D
-  <img width="616" height="377" alt="image" src="https://github.com/user-attachments/assets/3f3e90e5-6f35-4390-99b2-685446d9545c" />
-- Don't package the Movies folder into the .Pak file because MoviePlayer needs to look for the startup movies folder at "Contents/Movies" path
-- Make sure you don’t have any plugins enabled that conflict with ASL. For example, **Pre-Load Screen Movie Player**
 
 # Changelog
 

--- a/Source/AsyncLoadingScreen/Private/SBackgroundWidget.cpp
+++ b/Source/AsyncLoadingScreen/Private/SBackgroundWidget.cpp
@@ -17,23 +17,28 @@
 
 void SBackgroundWidget::Construct(const FArguments& InArgs, const FBackgroundSettings& Settings)
 {
-	Images = Settings.Images;
 	Interval = Settings.UpdateInterval;
 
 	// If there's an image defined
-	if (Images.Num() > 0)
+	if (Settings.Images.Num() > 0)
 	{
-		int32 ImageIndex = FMath::RandRange(0, Images.Num() - 1);
+		int32 ImageIndex = FMath::RandRange(0, Settings.Images.Num() - 1);
 
 		if (Settings.bSetDisplayBackgroundManually == true)
 		{
-			if (Images.IsValidIndex(UAsyncLoadingScreenLibrary::GetDisplayBackgroundIndex()))
+			if (Settings.Images.IsValidIndex(UAsyncLoadingScreenLibrary::GetDisplayBackgroundIndex()))
 			{
 				ImageIndex = UAsyncLoadingScreenLibrary::GetDisplayBackgroundIndex();
 			}
 		}		
-		
-		ImageBrush = FDeferredCleanupSlateBrush::CreateBrush(Images[ImageIndex]);
+		ImageBrushList.Empty();
+		for (auto& Image : Settings.Images)
+		{
+			if (Image)
+			{
+				ImageBrushList.Add(FDeferredCleanupSlateBrush::CreateBrush(Image.Get()));
+			}
+		}
 
 		// Load background from settings
 		ChildSlot
@@ -49,7 +54,7 @@ void SBackgroundWidget::Construct(const FArguments& InArgs, const FBackgroundSet
 							.Stretch(Settings.ImageStretch)
 							[
 								BackgroundWidget = SNew(SImage)
-									.Image(ImageBrush.IsValid() ? ImageBrush->GetSlateBrush() : nullptr)
+									.Image(ImageBrushList[ImageIndex].IsValid() ? ImageBrushList[ImageIndex]->GetSlateBrush() : nullptr)
 							]
 					]
 			];
@@ -59,17 +64,16 @@ void SBackgroundWidget::Construct(const FArguments& InArgs, const FBackgroundSet
 int32 SBackgroundWidget::OnPaint(const FPaintArgs& Args, const FGeometry& AllottedGeometry, const FSlateRect& MyCullingRect, FSlateWindowElementList& OutDrawElements, int32 LayerId, const FWidgetStyle& InWidgetStyle, bool bParentEnabled) const
 {
 	// Update the images if Interval > 0 and Images has more than one element
-	if (Interval > 0.0f && Images.Num() > 1)
+	if (Interval > 0.0f && ImageBrushList.Num() > 1)
 	{
 		TotalDeltaTime += Args.GetDeltaTime();
 
 		if (TotalDeltaTime >= Interval)
 		{
-			int32 ImageIndex = FMath::RandRange(0, Images.Num() - 1);
+			int32 ImageIndex = FMath::RandRange(0, ImageBrushList.Num() - 1);
 
 			// Load background from settings
-			ImageBrush = FDeferredCleanupSlateBrush::CreateBrush(Images[ImageIndex]);
-			StaticCastSharedRef<SImage>(BackgroundWidget)->SetImage(ImageBrush.IsValid() ? ImageBrush->GetSlateBrush() : nullptr);
+			StaticCastSharedRef<SImage>(BackgroundWidget)->SetImage(ImageBrushList[ImageIndex].IsValid() ? ImageBrushList[ImageIndex]->GetSlateBrush() : nullptr);
 
 			TotalDeltaTime = 0.0f;
 		}

--- a/Source/AsyncLoadingScreen/Private/SBackgroundWidget.cpp
+++ b/Source/AsyncLoadingScreen/Private/SBackgroundWidget.cpp
@@ -33,33 +33,26 @@ void SBackgroundWidget::Construct(const FArguments& InArgs, const FBackgroundSet
 			}
 		}		
 		
+		ImageBrush = FDeferredCleanupSlateBrush::CreateBrush(Images[ImageIndex]);
+
 		// Load background from settings
-		UTexture2D* LoadingImage = nullptr;
-		const FSoftObjectPath& ImageAsset = Images[ImageIndex];
-		UObject* ImageObject = ImageAsset.TryLoad();
-		LoadingImage = Cast<UTexture2D>(ImageObject);	
-		
-		if (LoadingImage)
-		{
-			ImageBrush = FDeferredCleanupSlateBrush::CreateBrush(LoadingImage);
-			ChildSlot
+		ChildSlot
 			[
 				SNew(SBorder)
-				.HAlign(HAlign_Fill)
-				.VAlign(VAlign_Fill)
-				.Padding(Settings.Padding)
-				.BorderBackgroundColor(Settings.BackgroundColor)
-				.BorderImage(FCoreStyle::Get().GetBrush("WhiteBrush"))
-				[
-					SNew(SScaleBox)
-					.Stretch(Settings.ImageStretch)
+					.HAlign(HAlign_Fill)
+					.VAlign(VAlign_Fill)
+					.Padding(Settings.Padding)
+					.BorderBackgroundColor(Settings.BackgroundColor)
+					.BorderImage(FCoreStyle::Get().GetBrush("WhiteBrush"))
 					[
-						BackgroundWidget = SNew(SImage)
-						.Image(ImageBrush.IsValid() ? ImageBrush->GetSlateBrush() : nullptr)						
+						SNew(SScaleBox)
+							.Stretch(Settings.ImageStretch)
+							[
+								BackgroundWidget = SNew(SImage)
+									.Image(ImageBrush.IsValid() ? ImageBrush->GetSlateBrush() : nullptr)
+							]
 					]
-				]
-			];			
-		}
+			];
 	}
 }
 
@@ -75,16 +68,8 @@ int32 SBackgroundWidget::OnPaint(const FPaintArgs& Args, const FGeometry& Allott
 			int32 ImageIndex = FMath::RandRange(0, Images.Num() - 1);
 
 			// Load background from settings
-			UTexture2D* LoadingImage = nullptr;
-			const FSoftObjectPath& ImageAsset = Images[ImageIndex];
-			UObject* ImageObject = ImageAsset.TryLoad();
-			LoadingImage = Cast<UTexture2D>(ImageObject);
-			
-			if (LoadingImage)
-			{
-				ImageBrush = FDeferredCleanupSlateBrush::CreateBrush(LoadingImage);
-				StaticCastSharedRef<SImage>(BackgroundWidget)->SetImage(ImageBrush.IsValid() ? ImageBrush->GetSlateBrush() : nullptr);				
-			}
+			ImageBrush = FDeferredCleanupSlateBrush::CreateBrush(Images[ImageIndex]);
+			StaticCastSharedRef<SImage>(BackgroundWidget)->SetImage(ImageBrush.IsValid() ? ImageBrush->GetSlateBrush() : nullptr);
 
 			TotalDeltaTime = 0.0f;
 		}

--- a/Source/AsyncLoadingScreen/Private/SLoadingWidget.cpp
+++ b/Source/AsyncLoadingScreen/Private/SLoadingWidget.cpp
@@ -71,7 +71,7 @@ void SLoadingWidget::ConstructLoadingIcon(const FLoadingWidgetSettings& Settings
 
 			FVector2D Scale = Settings.ImageSequenceSettings.Scale;
 
-			for (auto Image: Settings.ImageSequenceSettings.Images)
+			for (auto& Image : Settings.ImageSequenceSettings.Images)
 			{
 				if (Image)
 				{

--- a/Source/AsyncLoadingScreen/Public/LoadingScreenSettings.h
+++ b/Source/AsyncLoadingScreen/Public/LoadingScreenSettings.h
@@ -196,7 +196,7 @@ struct ASYNCLOADINGSCREEN_API FBackgroundSettings
 
 	// The images randomly display while in the loading screen on top of the movie 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Background", meta = (AllowedClasses = "/Script/Engine.Texture2D"))
-	TArray<FSoftObjectPath> Images;
+	TArray<TObjectPtr<UTexture2D>> Images;
 
 	// Interval time (in seconds) to randomly update the background image, a value less than or equal to 0 will not update the background image.
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Background")

--- a/Source/AsyncLoadingScreen/Public/SBackgroundWidget.h
+++ b/Source/AsyncLoadingScreen/Public/SBackgroundWidget.h
@@ -33,8 +33,9 @@ protected:
 	// Interval time (in seconds) to update the background, a value less than or equal to 0 will not update the background.
 	float Interval = 0.0f;
 
-	mutable TSharedPtr<FDeferredCleanupSlateBrush> ImageBrush = nullptr;
-	TArray<TObjectPtr<UTexture2D>> Images;
+	// Image slate brush list
+	TArray<TSharedPtr<FDeferredCleanupSlateBrush>> ImageBrushList;
+
 private:
 	// Placehold widget
 	TSharedRef<SWidget> BackgroundWidget = SNullWidget::NullWidget;

--- a/Source/AsyncLoadingScreen/Public/SBackgroundWidget.h
+++ b/Source/AsyncLoadingScreen/Public/SBackgroundWidget.h
@@ -30,14 +30,12 @@ protected:
 	// Current total delta time
 	mutable float TotalDeltaTime = 0.0f;
 
-	// Interval time (in seconds) to update the tip text, a value less than or equal to 0 will not update the tip text.
+	// Interval time (in seconds) to update the background, a value less than or equal to 0 will not update the background.
 	float Interval = 0.0f;
 
+	mutable TSharedPtr<FDeferredCleanupSlateBrush> ImageBrush = nullptr;
+	TArray<TObjectPtr<UTexture2D>> Images;
 private:
 	// Placehold widget
 	TSharedRef<SWidget> BackgroundWidget = SNullWidget::NullWidget;
-
-	TArray<FSoftObjectPath> Images;
-
-	mutable TSharedPtr<FDeferredCleanupSlateBrush> ImageBrush;
 };


### PR DESCRIPTION
This pull request updates the way background images are handled and displayed in the loading screen system, improving both performance and reliability. The main change is that background images are now referenced directly as `UTexture2D` pointers instead of asset paths, which simplifies image management and avoids runtime loading. Related code has been refactored to use this new approach, and the documentation has been updated with important packaging and setup notes.

**Background image handling improvements:**

* Changed the `Images` property in `FBackgroundSettings` from an array of `FSoftObjectPath` to an array of `TObjectPtr<UTexture2D>`, so images are referenced directly as assets rather than loaded at runtime.
* Refactored `SBackgroundWidget` to use a list of `FDeferredCleanupSlateBrush` objects (`ImageBrushList`) created from the `UTexture2D` pointers, eliminating dynamic asset loading and improving efficiency and reliability. [[1]](diffhunk://#diff-4d69cdf274efc06e88d3079cc86b65dbdc57a59ef99d2a1abb7f1be4ae443008L20-L44) [[2]](diffhunk://#diff-4d69cdf274efc06e88d3079cc86b65dbdc57a59ef99d2a1abb7f1be4ae443008L58-R76) [[3]](diffhunk://#diff-5169b802bf9aef61b66a2c313ede3d62983efa1e91df8b96267f03fac76ff4a4L33-L42)

**Documentation updates:**

* Moved and expanded the "IMPORTANT NOTE" section in `README.md`, providing clear instructions on texture settings, packaging, plugin conflicts, and asset cooking requirements for background images. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R8-L12) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R36-R41) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L69-L74)

**Code quality improvements:**

* Improved iteration style in `SLoadingWidget` for consistency and safety by adding a reference in the image loop.

These changes streamline the background image workflow and clarify setup steps for users, reducing common pitfalls and runtime issues.